### PR TITLE
fix "Error: Local: Queue full" error

### DIFF
--- a/rdkafka/rdkafka.js
+++ b/rdkafka/rdkafka.js
@@ -139,6 +139,15 @@ module.exports = function(RED) {
                     'batch.num.messages': 1000000,
                     'api.version.request': true  //added to force 0.10.x style timestamps on all messages
                 });
+            
+                producer.setPollInterval(100);
+
+                producer.on('delivery-report', function (err, report) {
+                    // Report of delivery statistics here:
+                    //
+                    //console.log(report);
+                });
+
 
                 // Connect to the broker manually
                 producer.connect();


### PR DESCRIPTION
  'queue.buffering.max.messages': 100000 in file rdkafka/rdkafka.js  defines the maximum number of messages in the transmission queue. If the number of message reaches this maximum number, following error will be seen in the node-red debug console:  

"Error: Local: Queue full", 

and **rdkafka**  output node stops producing new message.

producer.setPollInterval();  is added to fix the issue by referring following issue:
https://github.com/edenhill/librdkafka/issues/998



